### PR TITLE
rename field to frames_per_60_secs

### DIFF
--- a/src/ani/asset.rs
+++ b/src/ani/asset.rs
@@ -44,7 +44,7 @@ pub struct AnimatedCursor {
 
 impl AnimatedCursor {
     pub fn duration_per_frame(&self) -> Duration {
-        Duration::from_secs_f32(self.metadata.frames_per_60_seconds as f32 / 60.0)
+        Duration::from_secs_f32(self.metadata.frames_per_60_secs as f32 / 60.0)
     }
 }
 

--- a/src/ani/decoder.rs
+++ b/src/ani/decoder.rs
@@ -106,7 +106,7 @@ impl<R: Read + Seek> Decoder<R> {
                     height: cursor.read_u32::<LittleEndian>()?,
                     bit_count: cursor.read_u32::<LittleEndian>()?,
                     plane_count: cursor.read_u32::<LittleEndian>()?,
-                    frames_per_60_seconds: cursor.read_u32::<LittleEndian>()?,
+                    frames_per_60_secs: cursor.read_u32::<LittleEndian>()?,
                     flags: cursor.read_u32::<LittleEndian>()?,
                 })
             })

--- a/src/ani/mod.rs
+++ b/src/ani/mod.rs
@@ -30,7 +30,7 @@ pub struct AnimatedCursorMetadata {
     // The number of planes.
     pub plane_count: u32,
     // The number of frames per 60 seconds.
-    pub frames_per_60_seconds: u32,
+    pub frames_per_60_secs: u32,
     // The animation flags.
     //
     // TODO: Use bitflags.
@@ -114,7 +114,7 @@ mod tests {
                 height: 0,
                 bit_count: 0,
                 plane_count: 0,
-                frames_per_60_seconds: 10,
+                frames_per_60_secs: 10,
                 flags: 1,
             }
         );


### PR DESCRIPTION
Seems to better match idioms which using `_secs` suffix.