### PR TITLE
add cur decoder to help with RON visualizing

### DIFF
--- a/src/ani/mod.rs
+++ b/src/ani/mod.rs
@@ -169,7 +169,7 @@ mod tests {
         .iter()
         .collect();
 
-        let root_output_dir: PathBuf = [env!("CARGO_MANIFEST_DIR"), "decoded", "cursors"]
+        let root_output_dir: PathBuf = [env!("CARGO_MANIFEST_DIR"), "decoded", "animated-cursors"]
             .iter()
             .collect();
 

--- a/src/cur/decoder.rs
+++ b/src/cur/decoder.rs
@@ -1,0 +1,48 @@
+use std::{
+    fmt,
+    io::{Error as IoError, Read, Seek},
+};
+
+use ico::IconDir;
+
+use super::*;
+
+#[derive(Debug)]
+pub enum DecodeError {
+    IoError(IoError),
+}
+
+impl std::error::Error for DecodeError {}
+
+impl From<IoError> for DecodeError {
+    fn from(error: IoError) -> Self {
+        DecodeError::IoError(error)
+    }
+}
+
+impl fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DecodeError::IoError(e) => write!(f, "IO error: {}", e),
+        }
+    }
+}
+
+pub struct Decoder<R>
+where
+    R: Read + Seek,
+{
+    reader: R,
+}
+
+impl<R: Read + Seek> Decoder<R> {
+    pub fn new(reader: R) -> Self {
+        Decoder { reader }
+    }
+
+    pub fn decode(&mut self) -> Result<StaticCursor, DecodeError> {
+        let icon = IconDir::read(&mut self.reader)?;
+
+        Ok(StaticCursor(icon))
+    }
+}

--- a/src/cur/mod.rs
+++ b/src/cur/mod.rs
@@ -1,1 +1,145 @@
 pub mod asset;
+pub mod decoder;
+
+use ico::IconDir;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+pub struct StaticCursor(pub IconDir);
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "serde")]
+    use std::ffi::{OsStr, OsString};
+    use std::{
+        fs::File,
+        path::{Path, PathBuf},
+    };
+
+    use ico::ResourceType;
+
+    use crate::cur::decoder::Decoder;
+
+    #[test]
+    fn test_decode_hand_cur() {
+        let d: PathBuf = [
+            std::env::var("DARKOMEN_PATH").unwrap().as_str(),
+            "DARKOMEN",
+            "GRAPHICS",
+            "CURSORS",
+            "HAND.CUR",
+        ]
+        .iter()
+        .collect();
+
+        let file = File::open(d).unwrap();
+        let cursor = Decoder::new(file).decode().unwrap();
+
+        assert_eq!(cursor.0.resource_type(), ResourceType::Cursor);
+        assert_eq!(cursor.0.entries().len(), 1);
+
+        for entry in cursor.0.entries().iter() {
+            assert_eq!(entry.resource_type(), ResourceType::Cursor);
+
+            let icon_image = entry.decode().unwrap();
+            assert_eq!(icon_image.width(), 32);
+            assert_eq!(icon_image.height(), 32);
+
+            assert_eq!(icon_image.cursor_hotspot(), Some((10, 20)));
+        }
+    }
+
+    #[test]
+    fn test_decode_all() {
+        let d: PathBuf = [
+            std::env::var("DARKOMEN_PATH").unwrap().as_str(),
+            "DARKOMEN",
+            "GRAPHICS",
+            "CURSORS",
+        ]
+        .iter()
+        .collect();
+
+        let root_output_dir: PathBuf = [env!("CARGO_MANIFEST_DIR"), "decoded", "static-cursors"]
+            .iter()
+            .collect();
+
+        std::fs::create_dir_all(&root_output_dir).unwrap();
+
+        fn visit_dirs(dir: &Path, cb: &mut dyn FnMut(&Path)) {
+            println!("Reading dir {:?}", dir.display());
+
+            let mut paths = std::fs::read_dir(dir)
+                .unwrap()
+                .map(|res| res.map(|e| e.path()))
+                .collect::<Result<Vec<_>, std::io::Error>>()
+                .unwrap();
+
+            paths.sort();
+
+            for path in paths {
+                if path.is_dir() {
+                    visit_dirs(&path, cb);
+                } else {
+                    cb(&path);
+                }
+            }
+        }
+
+        visit_dirs(&d, &mut |path| {
+            let Some(ext) = path.extension() else {
+                return;
+            };
+            if ext.to_string_lossy().to_uppercase() != "CUR" {
+                return;
+            }
+
+            println!("Decoding {:?}", path.file_name().unwrap());
+
+            let file = File::open(path).unwrap();
+            let cursor = Decoder::new(file).decode().unwrap();
+
+            assert_eq!(cursor.0.resource_type(), ResourceType::Cursor);
+            assert_eq!(cursor.0.entries().len(), 1);
+
+            for entry in cursor.0.entries().iter() {
+                assert_eq!(entry.resource_type(), ResourceType::Cursor);
+
+                let icon_image = entry.decode().unwrap();
+                assert_eq!(icon_image.width(), 32);
+                assert_eq!(icon_image.height(), 32);
+            }
+
+            #[cfg(feature = "serde")]
+            {
+                let parent_dir = path
+                    .components()
+                    .collect::<Vec<_>>()
+                    .iter()
+                    .rev()
+                    .skip(1) // skip the file name
+                    .take_while(|c| c.as_os_str() != "DARKOMEN")
+                    .collect::<Vec<_>>()
+                    .iter()
+                    .rev()
+                    .collect::<PathBuf>();
+                let output_dir = root_output_dir.join(parent_dir);
+                std::fs::create_dir_all(&output_dir).unwrap();
+
+                let output_path = append_ext("ron", output_dir.join(path.file_name().unwrap()));
+                let mut output_file = File::create(output_path).unwrap();
+                ron::ser::to_writer_pretty(&mut output_file, &cursor, Default::default()).unwrap();
+            }
+        });
+    }
+
+    #[cfg(feature = "serde")]
+    fn append_ext(ext: impl AsRef<OsStr>, path: PathBuf) -> PathBuf {
+        let mut os_string: OsString = path.into();
+        os_string.push(".");
+        os_string.push(ext.as_ref());
+        os_string.into()
+    }
+}


### PR DESCRIPTION
- This adds a small amount of indirection/wrapping when decoding.
- Creates parity with the `ani` decoder style.
- Makes it easy to look at the decoded RON files, e.g. to see what the cursor hotspot value is for a given cursor.