### PR TITLE
add `CursorHotspots` for enhanced hotspot data

### DIFF
--- a/examples/ani.rs
+++ b/examples/ani.rs
@@ -57,7 +57,7 @@ fn insert_cursor(
             // flip_x: false,
             // flip_y: false,
             // rect: None,
-            hotspot: c.hotspots[texture_atlas_index],
+            hotspot: c.hotspot_or_default(texture_atlas_index),
         }));
 
     *setup = true;

--- a/examples/cur.rs
+++ b/examples/cur.rs
@@ -57,7 +57,7 @@ fn insert_cursor(
             // flip_x: false,
             // flip_y: false,
             // rect: None,
-            hotspot: c.hotspots[texture_atlas_index],
+            hotspot: c.hotspot_or_default(texture_atlas_index),
         }));
 
     *setup = true;

--- a/src/hotspot.rs
+++ b/src/hotspot.rs
@@ -1,0 +1,69 @@
+use std::collections::HashMap;
+
+use bevy_reflect::prelude::*;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// Hotspot data for a cursor.
+///
+/// This struct is used to store hotspot information for a cursor. The hotspot
+/// is the point in the cursor image that is used as the "click point" when
+/// interacting with a cursor.
+///
+/// A hotspot is defined as a pair of `(x, y)` coordinates, where `(0, 0)` is
+/// the top-left corner of the cursor's image.
+#[derive(Debug, Clone, Default, Reflect)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[reflect(Debug, Default)]
+#[cfg_attr(feature = "serde", reflect(Deserialize, Serialize))]
+pub struct CursorHotspots {
+    /// The default hotspot for the cursor.
+    ///
+    /// This is used when a frame does not have an entry in the `overrides` map.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub default: (u16, u16),
+    /// Overrides the hotspot for specific frames.
+    ///
+    /// The key is the frame index and the value is the hotspot for that frame.
+    ///
+    /// If a frame index is not present in this map, the `default` hotspot
+    /// should be used.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub overrides: HashMap<usize, (u16, u16)>,
+}
+
+impl CursorHotspots {
+    /// Returns the hotspot for the given frame index or the default hotspot.
+    ///
+    /// If the frame index is not present in the `overrides` map, the `default`
+    /// hotspot is returned.
+    pub fn get_or_default(&self, index: usize) -> (u16, u16) {
+        self.overrides.get(&index).copied().unwrap_or(self.default)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_or_default() {
+        let hotspots = CursorHotspots {
+            default: (10, 0),
+            overrides: HashMap::new(),
+        };
+
+        assert_eq!(hotspots.get_or_default(0), (10, 0));
+        assert_eq!(hotspots.get_or_default(1), (10, 0));
+        assert_eq!(hotspots.get_or_default(2), (10, 0));
+
+        let hotspots = CursorHotspots {
+            default: (10, 0),
+            overrides: vec![(1, (1, 1))].into_iter().collect(),
+        };
+
+        assert_eq!(hotspots.get_or_default(0), (10, 0));
+        assert_eq!(hotspots.get_or_default(1), (1, 1));
+        assert_eq!(hotspots.get_or_default(2), (10, 0));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ use crate::{ani::asset::AnimatedCursorAssetPlugin, cur::asset::StaticCursorAsset
 
 pub mod ani;
 pub mod cur;
+pub mod hotspot;
 
 pub mod prelude {
     #[doc(hidden)]


### PR DESCRIPTION
- Useful for a future feature whereby you can define cursors in text format, e.g. RON.
- In that case, you may not want to enumerate the hotspot for every single frame.
- Instead, you can set up a `default` and `overrides` like this:

```ron
(
    hotspots: CursorHotspots(
        default: (10, 20),
        overrides: {
            0: (15, 25),
            1: (12, 18),
        },
    ),
)
```

- To reduce the difference between this new type and the `hotspot` field that `AnimatedCursor` and `StaticCursor` have, they have been changed to use this as well.